### PR TITLE
Add validity checks for HTTP datagrams

### DIFF
--- a/PcapDotNet/src/PcapDotNet.Packets.Test/HttpTests.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets.Test/HttpTests.cs
@@ -108,6 +108,7 @@ namespace PcapDotNet.Packets.Test
                 if (httpLayer.Header != null)
                 {
                     Assert.AreEqual(httpLayer.Header.GetHashCode(), httpDatagram.Header.GetHashCode());
+                    Assert.IsTrue(httpDatagram.IsValidStart, "IsValidStart");
 
                     foreach (var field in httpLayer.Header)
                         Assert.IsFalse(field.Equals("abc"));

--- a/PcapDotNet/src/PcapDotNet.Packets.Test/HttpTests.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets.Test/HttpTests.cs
@@ -503,6 +503,14 @@ namespace PcapDotNet.Packets.Test
         }
 
         [TestMethod]
+        public void HttpRequestMissingMethodNotAllowed()
+        {
+            var packet = BuildPacket(" / HTTP/1.0\r\n\r\n");
+
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+        }
+
+        [TestMethod]
         public void HttpValidResponseTest()
         {
             var packet = BuildPacket("HTTP/1.0 200 OK\r\n\r\n");

--- a/PcapDotNet/src/PcapDotNet.Packets.Test/HttpTests.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets.Test/HttpTests.cs
@@ -475,7 +475,7 @@ namespace PcapDotNet.Packets.Test
         {
             var packet = BuildPacket("UnknownMethod / HTTP/1.0\r\n\r\n");
 
-            Assert.IsTrue(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+            Assert.IsTrue(packet.Ethernet.IpV4.Tcp.Http.IsValidStart);
         }
 
         [TestMethod]
@@ -483,7 +483,7 @@ namespace PcapDotNet.Packets.Test
         {
             var packet = BuildPacket("GET  HTTP/1.1\r\n\r\n");
 
-            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValidStart);
         }
 
         [TestMethod]
@@ -491,7 +491,7 @@ namespace PcapDotNet.Packets.Test
         {
             var packet = BuildPacket("GET / HTTP/\r\n\r\n");
 
-            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValidStart);
         }
 
         [TestMethod]
@@ -499,7 +499,7 @@ namespace PcapDotNet.Packets.Test
         {
             var packet = BuildPacket("GET /\r\n\r\n");
 
-            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValidStart);
         }
 
         [TestMethod]
@@ -507,7 +507,7 @@ namespace PcapDotNet.Packets.Test
         {
             var packet = BuildPacket(" / HTTP/1.0\r\n\r\n");
 
-            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValidStart);
         }
 
         [TestMethod]
@@ -515,7 +515,7 @@ namespace PcapDotNet.Packets.Test
         {
             var packet = BuildPacket("HTTP/1.0 200 OK\r\n\r\n");
 
-            Assert.IsTrue(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+            Assert.IsTrue(packet.Ethernet.IpV4.Tcp.Http.IsValidStart);
         }
 
         [TestMethod]
@@ -523,7 +523,7 @@ namespace PcapDotNet.Packets.Test
         {
             var packet = BuildPacket("HTTP/1.0 200 \r\n\r\n");
 
-            Assert.IsTrue(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+            Assert.IsTrue(packet.Ethernet.IpV4.Tcp.Http.IsValidStart);
         }
 
         [TestMethod]
@@ -531,7 +531,7 @@ namespace PcapDotNet.Packets.Test
         {
             var packet = BuildPacket("HTTP/ 200 OK\r\n\r\n");
 
-            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValidStart);
         }
 
         [TestMethod]
@@ -539,7 +539,7 @@ namespace PcapDotNet.Packets.Test
         {
             var packet = BuildPacket(" 200 OK\r\n\r\n");
 
-            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValidStart);
         }
 
         [TestMethod]
@@ -547,7 +547,7 @@ namespace PcapDotNet.Packets.Test
         {
             var packet = BuildPacket("HTTP/1.0  OK \r\n\r\n");
 
-            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValidStart);
         }
 
         private static void TestHttpRequest(string httpString, string expectedMethodString = null, string expectedUri = null, HttpVersion expectedVersion = null, HttpHeader expectedHeader = null, string expectedBodyString = null)

--- a/PcapDotNet/src/PcapDotNet.Packets.Test/HttpTests.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets.Test/HttpTests.cs
@@ -472,7 +472,7 @@ namespace PcapDotNet.Packets.Test
         }
 
         [TestMethod]
-        public void HttpMinimalValidRequestTest()
+        public void HttpIsValidStartRequestValidTest()
         {
             var packet = BuildPacket("UnknownMethod / HTTP/1.0\r\n\r\n");
 
@@ -480,7 +480,7 @@ namespace PcapDotNet.Packets.Test
         }
 
         [TestMethod]
-        public void HttpRequestEmptyRequestUriNotAllowed()
+        public void HttpIsValidStartRequestWithMissingUriNotAllowedTest()
         {
             var packet = BuildPacket("GET  HTTP/1.1\r\n\r\n");
 
@@ -488,7 +488,7 @@ namespace PcapDotNet.Packets.Test
         }
 
         [TestMethod]
-        public void HttpRequestMissingVersionNumberNotAllowed()
+        public void HttpIsValidStartRequestWithMissingVersionNumberNotAllowedTest()
         {
             var packet = BuildPacket("GET / HTTP/\r\n\r\n");
 
@@ -496,7 +496,7 @@ namespace PcapDotNet.Packets.Test
         }
 
         [TestMethod]
-        public void HttpRequestMissingVersionNotAllowed()
+        public void HttpIsValidStartRequestWithMissingVersionNotAllowedTest()
         {
             var packet = BuildPacket("GET /\r\n\r\n");
 
@@ -504,7 +504,7 @@ namespace PcapDotNet.Packets.Test
         }
 
         [TestMethod]
-        public void HttpRequestMissingMethodNotAllowed()
+        public void HttpIsValidStartRequestWithMissingMethodNotAllowedTest()
         {
             var packet = BuildPacket(" / HTTP/1.0\r\n\r\n");
 
@@ -512,7 +512,7 @@ namespace PcapDotNet.Packets.Test
         }
 
         [TestMethod]
-        public void HttpValidResponseTest()
+        public void HttpIsValidStartResponseValidTest()
         {
             var packet = BuildPacket("HTTP/1.0 200 OK\r\n\r\n");
 
@@ -520,7 +520,7 @@ namespace PcapDotNet.Packets.Test
         }
 
         [TestMethod]
-        public void HttpMinimalResponseTest()
+        public void HttpIsValidStartResponseMinimalValidTest()
         {
             var packet = BuildPacket("HTTP/1.0 200 \r\n\r\n");
 
@@ -528,7 +528,7 @@ namespace PcapDotNet.Packets.Test
         }
 
         [TestMethod]
-        public void HttpResponseMissingVersionNumberNotAllowed()
+        public void HttpIsValidStartResponseWithMissingVersionNumberNotAllowedTest()
         {
             var packet = BuildPacket("HTTP/ 200 OK\r\n\r\n");
 
@@ -536,7 +536,7 @@ namespace PcapDotNet.Packets.Test
         }
 
         [TestMethod]
-        public void HttpResponseMissingVersionNotAllowed()
+        public void HttpIsValidStartResponseWithMissingVersionNotAllowed()
         {
             var packet = BuildPacket(" 200 OK\r\n\r\n");
 
@@ -544,7 +544,7 @@ namespace PcapDotNet.Packets.Test
         }
 
         [TestMethod]
-        public void HttpResponseMissingStatusCodeNotAllowed()
+        public void HttpIsValidStartResponseWithMissingStatusCodeNotAllowedTest()
         {
             var packet = BuildPacket("HTTP/1.0  OK \r\n\r\n");
 

--- a/PcapDotNet/src/PcapDotNet.Packets.Test/HttpTests.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets.Test/HttpTests.cs
@@ -470,6 +470,38 @@ namespace PcapDotNet.Packets.Test
             Assert.IsNotNull(new HttpRequestMethod(HttpRequestKnownMethod.Unknown));
         }
 
+        [TestMethod]
+        public void HttpMinimalValidRequestTest()
+        {
+            var packet = BuildPacket("UnknownMethod / HTTP/1.0\r\n\r\n");
+
+            Assert.IsTrue(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+        }
+
+        [TestMethod]
+        public void HttpRequestEmptyRequestUriNotAllowed()
+        {
+            var packet = BuildPacket("GET  HTTP/1.1\r\n\r\n");
+
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+        }
+
+        [TestMethod]
+        public void HttpRequestMissingVersionNumberNotAllowed()
+        {
+            var packet = BuildPacket("GET / HTTP/\r\n\r\n");
+
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+        }
+
+        [TestMethod]
+        public void HttpRequestMissingVersionNotAllowed()
+        {
+            var packet = BuildPacket("GET /\r\n\r\n");
+
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+        }
+
         private static void TestHttpRequest(string httpString, string expectedMethodString = null, string expectedUri = null, HttpVersion expectedVersion = null, HttpHeader expectedHeader = null, string expectedBodyString = null)
         {
             Datagram expectedBody = expectedBodyString == null ? null : new Datagram(Encoding.ASCII.GetBytes(expectedBodyString));

--- a/PcapDotNet/src/PcapDotNet.Packets.Test/HttpTests.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets.Test/HttpTests.cs
@@ -502,6 +502,46 @@ namespace PcapDotNet.Packets.Test
             Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
         }
 
+        [TestMethod]
+        public void HttpValidResponseTest()
+        {
+            var packet = BuildPacket("HTTP/1.0 200 OK\r\n\r\n");
+
+            Assert.IsTrue(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+        }
+
+        [TestMethod]
+        public void HttpMinimalResponseTest()
+        {
+            var packet = BuildPacket("HTTP/1.0 200 \r\n\r\n");
+
+            Assert.IsTrue(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+        }
+
+        [TestMethod]
+        public void HttpResponseMissingVersionNumberNotAllowed()
+        {
+            var packet = BuildPacket("HTTP/ 200 OK\r\n\r\n");
+
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+        }
+
+        [TestMethod]
+        public void HttpResponseMissingVersionNotAllowed()
+        {
+            var packet = BuildPacket(" 200 OK\r\n\r\n");
+
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+        }
+
+        [TestMethod]
+        public void HttpResponseMissingStatusCodeNotAllowed()
+        {
+            var packet = BuildPacket("HTTP/1.0  OK \r\n\r\n");
+
+            Assert.IsFalse(packet.Ethernet.IpV4.Tcp.Http.IsValid);
+        }
+
         private static void TestHttpRequest(string httpString, string expectedMethodString = null, string expectedUri = null, HttpVersion expectedVersion = null, HttpHeader expectedHeader = null, string expectedBodyString = null)
         {
             Datagram expectedBody = expectedBodyString == null ? null : new Datagram(Encoding.ASCII.GetBytes(expectedBodyString));

--- a/PcapDotNet/src/PcapDotNet.Packets/Http/HttpDatagram.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets/Http/HttpDatagram.cs
@@ -239,7 +239,23 @@ namespace PcapDotNet.Packets.Http
         /// </summary>
         public Datagram Body { get; private set; }
 
-        public virtual bool IsValidStart => false;
+        /// <summary>
+        /// True if this datagram contains a valid start for an HTTP message.
+        /// </summary>
+        public bool IsValidStart
+        {
+            get
+            {
+                if (_isValidStart == null)
+                    _isValidStart = CalculateIsValidStart();
+                return _isValidStart.Value;
+            }
+        }
+
+        /// <summary>
+        /// Calculate whether the HTTP datagram has a valid start. 
+        /// </summary>
+        protected abstract bool CalculateIsValidStart();
 
         internal static HttpDatagram CreateDatagram(byte[] buffer, int offset, int length)
         {
@@ -357,5 +373,7 @@ namespace PcapDotNet.Packets.Http
         }
 
         private static readonly byte[] _httpSlash = Encoding.ASCII.GetBytes("HTTP/");
+
+        private bool? _isValidStart;
     }
 }

--- a/PcapDotNet/src/PcapDotNet.Packets/Http/HttpDatagram.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets/Http/HttpDatagram.cs
@@ -239,6 +239,8 @@ namespace PcapDotNet.Packets.Http
         /// </summary>
         public Datagram Body { get; private set; }
 
+        public virtual bool IsValidStart => false;
+
         internal static HttpDatagram CreateDatagram(byte[] buffer, int offset, int length)
         {
             if (length >= _httpSlash.Length && buffer.SequenceEqual(offset, _httpSlash, 0, _httpSlash.Length))

--- a/PcapDotNet/src/PcapDotNet.Packets/Http/HttpRequestDatagram.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets/Http/HttpRequestDatagram.cs
@@ -46,6 +46,18 @@ namespace PcapDotNet.Packets.Http
                        Body = Body,
                    };
         }
+        
+        /// <summary>
+        /// An HTTP Request is valid if it contains a method, an URI, and a version.
+        /// </summary>
+        protected override bool CalculateIsValid()
+        {
+            if (_isValid == null)
+            {
+                _isValid = Method != null && !string.IsNullOrEmpty(Uri) && Version != null;
+            }
+            return _isValid.Value;
+        }
 
         internal HttpRequestDatagram(byte[] buffer, int offset, int length) 
             : this(buffer, offset, Parse(buffer, offset, length))
@@ -99,5 +111,7 @@ namespace PcapDotNet.Packets.Http
         {
             return header.ContentLength != null;
         }
+
+        private bool? _isValid;
     }
 }

--- a/PcapDotNet/src/PcapDotNet.Packets/Http/HttpRequestDatagram.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets/Http/HttpRequestDatagram.cs
@@ -46,20 +46,13 @@ namespace PcapDotNet.Packets.Http
                        Body = Body,
                    };
         }
-        
+
         /// <summary>
         /// An HTTP Request has a valid start if it contains a method, an URI, and a version.
         /// </summary>
-        public override bool IsValidStart
+        protected override bool CalculateIsValidStart()
         {
-            get
-            {
-                if (_isValidStart == null)
-                {
-                    _isValidStart = Method != null && !string.IsNullOrEmpty(Uri) && Version != null;
-                }
-                return _isValidStart.Value;
-            }
+            return Method != null && !string.IsNullOrEmpty(Uri) && Version != null;
         }
 
         internal HttpRequestDatagram(byte[] buffer, int offset, int length) 
@@ -114,7 +107,5 @@ namespace PcapDotNet.Packets.Http
         {
             return header.ContentLength != null;
         }
-
-        private bool? _isValidStart;
     }
 }

--- a/PcapDotNet/src/PcapDotNet.Packets/Http/HttpRequestDatagram.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets/Http/HttpRequestDatagram.cs
@@ -48,15 +48,18 @@ namespace PcapDotNet.Packets.Http
         }
         
         /// <summary>
-        /// An HTTP Request is valid if it contains a method, an URI, and a version.
+        /// An HTTP Request has a valid start if it contains a method, an URI, and a version.
         /// </summary>
-        protected override bool CalculateIsValid()
+        public override bool IsValidStart
         {
-            if (_isValid == null)
+            get
             {
-                _isValid = Method != null && !string.IsNullOrEmpty(Uri) && Version != null;
+                if (_isValidStart == null)
+                {
+                    _isValidStart = Method != null && !string.IsNullOrEmpty(Uri) && Version != null;
+                }
+                return _isValidStart.Value;
             }
-            return _isValid.Value;
         }
 
         internal HttpRequestDatagram(byte[] buffer, int offset, int length) 
@@ -112,6 +115,6 @@ namespace PcapDotNet.Packets.Http
             return header.ContentLength != null;
         }
 
-        private bool? _isValid;
+        private bool? _isValidStart;
     }
 }

--- a/PcapDotNet/src/PcapDotNet.Packets/Http/HttpResponseDatagram.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets/Http/HttpResponseDatagram.cs
@@ -53,16 +53,9 @@ namespace PcapDotNet.Packets.Http
         /// <summary>
         /// A HTTP response has a valid start if it contains a version and a status code.
         /// </summary>
-        public override bool IsValidStart
+        protected override bool CalculateIsValidStart()
         {
-            get
-            {
-                if (_isValidStart == null)
-                {
-                    _isValidStart = Version != null && StatusCode != null;
-                }
-                return _isValidStart.Value;
-            }
+            return Version != null && StatusCode != null;
         }
 
         internal HttpResponseDatagram(byte[] buffer, int offset, int length) 
@@ -119,7 +112,5 @@ namespace PcapDotNet.Packets.Http
                 return false;
             return true;
         }
-
-        private bool? _isValidStart;
     }
 }

--- a/PcapDotNet/src/PcapDotNet.Packets/Http/HttpResponseDatagram.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets/Http/HttpResponseDatagram.cs
@@ -51,15 +51,18 @@ namespace PcapDotNet.Packets.Http
         }
 
         /// <summary>
-        /// A HTTP response is valid if it contains a version and a status code.
+        /// A HTTP response has a valid start if it contains a version and a status code.
         /// </summary>
-        protected override bool CalculateIsValid()
+        public override bool IsValidStart
         {
-            if (_isValid == null)
+            get
             {
-                _isValid = Version != null && StatusCode != null;
+                if (_isValidStart == null)
+                {
+                    _isValidStart = Version != null && StatusCode != null;
+                }
+                return _isValidStart.Value;
             }
-            return _isValid.Value;
         }
 
         internal HttpResponseDatagram(byte[] buffer, int offset, int length) 
@@ -117,6 +120,6 @@ namespace PcapDotNet.Packets.Http
             return true;
         }
 
-        private bool? _isValid;
+        private bool? _isValidStart;
     }
 }

--- a/PcapDotNet/src/PcapDotNet.Packets/Http/HttpResponseDatagram.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets/Http/HttpResponseDatagram.cs
@@ -50,6 +50,18 @@ namespace PcapDotNet.Packets.Http
             };
         }
 
+        /// <summary>
+        /// A HTTP response is valid if it contains a version and a status code.
+        /// </summary>
+        protected override bool CalculateIsValid()
+        {
+            if (_isValid == null)
+            {
+                _isValid = Version != null && StatusCode != null;
+            }
+            return _isValid.Value;
+        }
+
         internal HttpResponseDatagram(byte[] buffer, int offset, int length) 
             : this(buffer, offset, Parse(buffer, offset, length))
         {
@@ -104,5 +116,7 @@ namespace PcapDotNet.Packets.Http
                 return false;
             return true;
         }
+
+        private bool? _isValid;
     }
 }

--- a/PcapDotNet/src/PcapDotNet.Packets/Http/HttpResponseDatagram.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets/Http/HttpResponseDatagram.cs
@@ -51,7 +51,7 @@ namespace PcapDotNet.Packets.Http
         }
 
         /// <summary>
-        /// A HTTP response has a valid start if it contains a version and a status code.
+        /// An HTTP response has a valid start if it contains a version and a status code.
         /// </summary>
         protected override bool CalculateIsValidStart()
         {


### PR DESCRIPTION
Added overloads for the `CalculateIsValid ` method in `HttpRequestDatagram` and `HttpResponseDatagram`. This allows to check whether a HTTP datagram is actually a valid datagram before parsing it.

According to the RFCs of HTTP/1.0 and 1.1 a HTTP request must contain at least a method, an URI, and the version. So `HttpRequestDatagram.CalculateIsValid()` returns `true` if the parsed method, URI, and version are not `null` (or empty in case of the URI string).

For responses, the RFCs require at least the version, status code, and a reason phrase. Since the reason phrase can be basically any string I excluded it from the validity check and just check the version and status code. So `HttpResponseDatagram.CalculateIsValid()` returns `true` if the parsed version and the status code are not `null`.

This pull request also includes unit tests for the different cases of missing / present values for the mentioned elements.