### PR TITLE
Fix non-deterministically failing RandomHttpTest

### DIFF
--- a/PcapDotNet/src/PcapDotNet.Packets.TestUtils/RandomHttpExtensions.cs
+++ b/PcapDotNet/src/PcapDotNet.Packets.TestUtils/RandomHttpExtensions.cs
@@ -138,7 +138,7 @@ namespace PcapDotNet.Packets.TestUtils
 
         public static string NextHttpUri(this Random random)
         {
-            int uriLength = random.Next(100);
+            int uriLength = random.Next(1, 100);
             StringBuilder stringBuilder = new StringBuilder();
             for (int i = 0; i != uriLength; ++i)
                 stringBuilder.Append(random.NextChar((char)33, (char)127));


### PR DESCRIPTION
The test simply failed sometimes because the Uri was generated to be empty. So the fix simply ensures that the Uri always has at least one char.